### PR TITLE
fix: README - align with TestMu AI branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-﻿# Run Karate Selenium Tests on TestMu AI (Formerly LambdaTest)
+# Run Karate Selenium Tests on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
-  <a href="https://github.com/LambdaTest/karate-selenium-sample"><img src="https://img.shields.io/github/stars/LambdaTest/karate-selenium-sample?style=for-the-badge&labelColor=000" alt="GitHub Stars"></a>
   <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
 
@@ -10,10 +9,10 @@
 
 [TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-With TestMu AI (Formerly LambdaTest), you can run Karate Selenium tests across real browsers and operating systems. This sample shows how to configure Karate framework Selenium tests to run on the TestMu AI cloud.
+With TestMu AI (Formerly LambdaTest), you can run Karate Selenium tests across real browsers and operating systems using the Karate framework.
 
-- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
-- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
+- Sign up on TestMu AI (Formerly LambdaTest).
+- Follow the TestMu AI Documentation for the full setup walkthrough.
 
 ### Prerequisites
 
@@ -55,7 +54,7 @@ def session = { capabilities: { browserName: 'chrome' }, desiredCapabilities: { 
 
 ### Run tests
 
-Run your Karate Selenium tests on the TestMu AI grid:
+Run your Karate Selenium tests on the TestMu AI (Formerly LambdaTest) grid:
 
 ```bash
 mvn test -Dhub=https://$LT_USERNAME:$LT_ACCESS_KEY@hub.lambdatest.com/wd/hub
@@ -77,7 +76,7 @@ def session = { capabilities: { browserName: 'chrome', tunnel: true }, desiredCa
 
 ## Contributions
 
-Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and Angular CLI version.
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Java version, OS, and Maven version.
 
 ## TestMu AI (Formerly LambdaTest) Community
 


### PR DESCRIPTION
Aligns README with TestMu AI branding: updated H1 title, badge block, brand names, and links per guidelines.